### PR TITLE
Fix failing i386 test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@
 # RStudio files
 .Rproj.user/
 
+# vscode settings
+.vscode/settings.json
+
 # produced vignettes
 vignettes/*.html
 vignettes/*.pdf

--- a/R/BuildTree.R
+++ b/R/BuildTree.R
@@ -200,6 +200,9 @@ BuildTree <- function(X, Y, FUN, paramList, min.parent, max.depth, bagging, repl
     # determine class proportions in the node
     ClassCounts <- tabulate(Y[Assigned2Node[[CurrentNode]]], nClasses)
     ClProb <- ClassCounts / NdSize
+    if (any(is.nan(ClProb))){
+      return (BuildTree(X, Y, FUN, paramList, min.parent, max.depth, bagging, replacement, stratify, class.ind, class.ct, store.oob, store.impurity, progress, rotate))
+    }
     # compute impurity for current node
     I <- sum(ClassCounts * (1 - ClProb))
     # check to see if node split should be attempted

--- a/tests/testthat/test-Urerf.R
+++ b/tests/testthat/test-Urerf.R
@@ -62,7 +62,7 @@ test_that("matrix attributes are legal", {
 test_that("output is the right size and type", {
   X <- as.matrix(iris[, 1:4])
 
-  similarityMatrix <- Urerf(X, 100, 10)$similarityMatrix
+  similarityMatrix <- Urerf(X, 100, 10, Progress = FALSE)$similarityMatrix
 
 
   expect_equal(nrow(similarityMatrix), 150)

--- a/tests/testthat/test-general.R
+++ b/tests/testthat/test-general.R
@@ -27,7 +27,11 @@ test_that("Testing number of trees output is as requested.", {
 # should be > 0, probability be > 0, or sum ~= 1
 test_that("Sum of the class probabilities should ~= 1.", {
   numTrees = 10
-  forest <- RerF(X, Y, trees = numTrees, seed = 1L, num.cores = 1L, store.oob = FALSE)
+  forest <- RerF(X, Y,
+                 seed = 1L, num.cores = 1L, store.oob = TRUE, min.parent = 1,
+                 max.depth = 0
+  )
+  # forest <- RerF(X, Y, trees = numTrees, seed = 1L, num.cores = 1L, store.oob = FALSE)
   for (z in 1:length(forest$trees)) {
     for (q in 1:length(forest$trees[[z]]$ClassProb[, 1])) {
       expect_equal(sum(forest$trees[[z]]$ClassProb[q, ]), 1, tolerance = 1e-08)

--- a/tests/testthat/test-general.R
+++ b/tests/testthat/test-general.R
@@ -33,8 +33,7 @@ test_that("Sum of the class probabilities should ~= 1.", {
   )
   # forest <- RerF(X, Y, trees = numTrees, seed = 1L, num.cores = 1L, store.oob = FALSE)
   for (z in 1:length(forest$trees)) {
-    for (q in 1:length(forest$trees[[z]]$ClassProb[, 1])) {
-      expect_equal(sum(forest$trees[[z]]$ClassProb[q, ]), 1, tolerance = 1e-08)
-    }
+    treeClassProb <- forest$trees[[z]]$ClassProb
+    expect_equal(rowSums(treeClassProb), rep(1, nrow(treeClassProb)))
   }
 })


### PR DESCRIPTION
The problem was that we were splitting in such a way that resulted in an empty node.  This only happened on i386 and windows.

For reference, the error occurred on the test predictions file, on the first OOB prediction:

```r
test_that("Iris OOB Predictions", {
  # Build as large of trees as possible
  forest <- RerF(X, Y,
    seed = 1L, num.cores = 1L, store.oob = TRUE, min.parent = 1,
    max.depth = 0
  )
  oob.predictions <- OOBPredict(X, forest, num.cores = 1L)
  accuracy <- mean(Y == oob.predictions)
  expect_equal(accuracy, 143 / 150)

  # Limit depth of trees
  forest <- RerF(X, Y,
    seed = 1L, num.cores = 1L, store.oob = TRUE, min.parent = 1,
    max.depth = 2
  )
  oob.predictions <- OOBPredict(X, forest, num.cores = 2L)
  accuracy <- mean(Y == oob.predictions)
  expect_equal(accuracy, 133 / 150)
})
```

4 potential solutions:

1. Set a new seed.  Yes... this actually gets the tests to pass...
1. *if ClProb has any NaNs, we set it to `ClProb <- rep(1/length(ClassCounts),length(ClassCounts))` and continue building the tree* This also passes tests, but just is messy.  It would result in at least one node with zero elements. Also, when doing predictions, elements that traverse the tree down to the node with zero elements would not yield any useful information.  I tested this and it passes as well.  
1. *if ClProb has any NaNs we throw out the tree and start over.*  This is a better solution in that we won't ever result in trees that have nodes of zero length. The one issue with this is that having to restart growing trees like this could get us into trouble (slightly slower, possible infinite loop in some weird edge cases), but the problem occurs so rarely that this shouldn't be a problem.  And it has the advantage of never having trees with nodes of zero length.
1. the proper, more long term solution, would be to fix the cause of the error - *we should never split in the first place when the result would be a node of zero length*.  This is a fix which would take me a longer amount of time and I think we should tackle in the next release.

I chose option 3 for this PR.  I vote we do option 4 in the next Sprint.