### PR TITLE
speed up travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: r
+sudo: false
+cache: packages
 
 r:
   - release

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 language: r
-dist: trusty
 
 r:
   - release
-
-sudo: false
 
 addons:
   apt:


### PR DESCRIPTION
this seems to speed up the travis builds by about 50%.

i believe the big improvement is from cacheing the packages

the suggestion from the following blog post is to use remotes instead of the `r_packages` entry we currently have in the travis.yml file, but I haven't tried that.

https://blog.rstudio.com/2016/03/09/r-on-travis-ci/

related to #123 